### PR TITLE
fix: address PR #3615 Copilot review comments

### DIFF
--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -604,12 +604,4 @@ async def get_config_entries(
             required=False,
             value=(cast("str", values.get(CONF_DIRECT_ACCESS_TOKEN)) if values else None),
         ),
-        ConfigEntry(
-            key=CONF_DIRECT_CLIENT_SECRET,
-            type=ConfigEntryType.SECURE_STRING,
-            label="Direct Client Secret",
-            hidden=True,
-            required=False,
-            value=(cast("str", values.get(CONF_DIRECT_CLIENT_SECRET)) if values else None),
-        ),
     )

--- a/provider/cloud.py
+++ b/provider/cloud.py
@@ -71,8 +71,11 @@ class CloudManager:
                 self._logger.exception(
                     "Cloud connection error, reconnecting in %ds", self._reconnect_delay
                 )
-                await asyncio.sleep(self._reconnect_delay)
-                self._reconnect_delay = min(self._reconnect_delay * 2, CLOUD_RECONNECT_MAX)
+            if not self._running:
+                break
+            # Backoff before reconnect (both after errors and clean disconnects)
+            await asyncio.sleep(self._reconnect_delay)
+            self._reconnect_delay = min(self._reconnect_delay * 2, CLOUD_RECONNECT_MAX)
 
     async def _connect_once(self) -> None:
         """Single WebSocket connection attempt + message loop."""

--- a/provider/cloud.py
+++ b/provider/cloud.py
@@ -72,7 +72,7 @@ class CloudManager:
                     "Cloud connection error, reconnecting in %ds", self._reconnect_delay
                 )
             if not self._running:
-                break
+                break  # type: ignore[unreachable]
             # Backoff before reconnect (both after errors and clean disconnects)
             await asyncio.sleep(self._reconnect_delay)
             self._reconnect_delay = min(self._reconnect_delay * 2, CLOUD_RECONNECT_MAX)

--- a/provider/device.py
+++ b/provider/device.py
@@ -238,9 +238,9 @@ async def execute_capability_action(
 
         elif action.type == YandexCapabilityType.RANGE and instance == INSTANCE_VOLUME:
             if action.state.relative:
-                target = max(0, min(100, current_volume + int(value)))
+                target = max(0, min(100, current_volume + int(float(value))))
             else:
-                target = max(0, min(100, int(value)))
+                target = max(0, min(100, int(float(value))))
             await mass.players.cmd_volume_set(player_id, target)
             value = target
 
@@ -255,14 +255,26 @@ async def execute_capability_action(
 
         elif action.type == YandexCapabilityType.RANGE and instance == INSTANCE_CHANNEL:
             if action.state.relative:
-                if int(value) > 0:
+                if int(float(value)) > 0:
                     await mass.players.cmd_next_track(player_id)
-                elif int(value) < 0:
+                elif int(float(value)) < 0:
                     await mass.players.cmd_previous_track(player_id)
             # Non-relative channel set is ignored (no concept of channel number in MA)
 
         elif action.type == YandexCapabilityType.MODE and instance == INSTANCE_INPUT_SOURCE:
             player = mass.players.get_player(player_id)
+            if player is None:
+                return CapabilityActionResult(
+                    type=action.type,
+                    state=CapabilityActionResultState(
+                        instance=instance,
+                        action_result=ActionResult(
+                            status="ERROR",
+                            error_code=ERROR_DEVICE_UNREACHABLE,
+                            error_message=f"Player {player_id} not found",
+                        ),
+                    ),
+                )
             p_state = player.state if hasattr(player, "state") else player
             source_list = _get_source_list(p_state)
             source = _mode_to_source(str(value), source_list)
@@ -294,6 +306,18 @@ async def execute_capability_action(
                 ),
             )
 
+    except (ValueError, TypeError):
+        return CapabilityActionResult(
+            type=action.type,
+            state=CapabilityActionResultState(
+                instance=instance,
+                action_result=ActionResult(
+                    status="ERROR",
+                    error_code=ERROR_INVALID_ACTION,
+                    error_message=f"Invalid value for {action.type}/{instance}: {value}",
+                ),
+            ),
+        )
     except Exception:
         _LOGGER.exception("Error executing action %s/%s on %s", action.type, instance, player_id)
         return CapabilityActionResult(

--- a/provider/direct.py
+++ b/provider/direct.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import html as html_module
 import logging
+import secrets
 import time
 import urllib.parse
 import uuid
@@ -182,7 +183,7 @@ class DirectConnectionHandler:
             return False
         auth = request.headers.get("Authorization", "")
         if auth.startswith("Bearer "):
-            return auth[7:] == self._access_token
+            return secrets.compare_digest(auth[7:], self._access_token)
         return False
 
     def _unauthorized_response(self, request_id: str = "") -> web.Response:

--- a/provider/handlers.py
+++ b/provider/handlers.py
@@ -142,12 +142,18 @@ def parse_action_payload(raw: dict[str, Any]) -> ActionRequestPayload:
     """Parse a raw /user/devices/action message into ActionRequestPayload."""
     devices = []
     for dev_raw in raw.get("payload", raw).get("devices", []):
+        dev_id = dev_raw.get("id")
+        if not dev_id:
+            continue
         capabilities = []
         for cap_raw in dev_raw.get("capabilities", []):
+            cap_type = cap_raw.get("type")
+            if not cap_type:
+                continue
             state_raw = cap_raw.get("state", {})
             capabilities.append(
                 CapabilityAction(
-                    type=cap_raw["type"],
+                    type=cap_type,
                     state=CapabilityActionState(
                         instance=state_raw.get("instance", ""),
                         value=state_raw.get("value"),
@@ -155,7 +161,7 @@ def parse_action_payload(raw: dict[str, Any]) -> ActionRequestPayload:
                     ),
                 )
             )
-        devices.append(DeviceAction(id=dev_raw["id"], capabilities=capabilities))
+        devices.append(DeviceAction(id=dev_id, capabilities=capabilities))
     return ActionRequestPayload(devices=devices)
 
 

--- a/provider/plugin.py
+++ b/provider/plugin.py
@@ -198,6 +198,10 @@ class YandexSmartHomePlugin(PluginProvider):
             )
             return
 
+        if not self._direct_client_secret:
+            self.logger.error("Direct mode requires a client secret for OAuth account linking")
+            return
+
         self._user_id = self._instance_name
 
         def _on_token_created(token: str) -> None:


### PR DESCRIPTION
Address open Copilot review comments from music-assistant/server PR #3615:

- **Security**: Use `secrets.compare_digest` for Bearer token validation (timing attack prevention)
- **Reliability**: Add reconnect backoff on clean WebSocket disconnect (prevent tight loop)
- **Validation**: Check `direct_client_secret` is non-empty before starting direct mode
- **Robustness**: Make `parse_action_payload` defensive with `.get()` for required keys
- **Null safety**: Handle `get_player()` returning `None` in input_source mode
- **Error handling**: Explicit `ValueError`/`TypeError` catch for numeric conversions (returns `INVALID_ACTION` instead of `INTERNAL_ERROR`)
- **Config**: Remove duplicate `CONF_DIRECT_CLIENT_SECRET` config entry