### PR TITLE
fix: address PR #3615 review comments (round 2)

### DIFF
--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -604,12 +604,4 @@ async def get_config_entries(
             required=False,
             value=(cast("str", values.get(CONF_DIRECT_ACCESS_TOKEN)) if values else None),
         ),
-        ConfigEntry(
-            key=CONF_DIRECT_CLIENT_SECRET,
-            type=ConfigEntryType.SECURE_STRING,
-            label="Direct Client Secret",
-            hidden=True,
-            required=False,
-            value=(cast("str", values.get(CONF_DIRECT_CLIENT_SECRET)) if values else None),
-        ),
     )

--- a/provider/cloud.py
+++ b/provider/cloud.py
@@ -154,8 +154,10 @@ async def register_cloud_instance(
     For Cloud Plus mode, pass platform="yandex" so the relay can validate
     the client_id during OAuth account linking.
     """
-    json_body = {"platform": platform} if platform else None
-    async with session.post(CLOUD_REGISTER_URL, json=json_body) as resp:
+    kwargs: dict[str, Any] = {}
+    if platform:
+        kwargs["json"] = {"platform": platform}
+    async with session.post(CLOUD_REGISTER_URL, **kwargs) as resp:
         resp.raise_for_status()
         # yaha-cloud.ru may return text/plain content-type for JSON
         data = await resp.json(content_type=None)

--- a/provider/cloud.py
+++ b/provider/cloud.py
@@ -71,8 +71,11 @@ class CloudManager:
                 self._logger.exception(
                     "Cloud connection error, reconnecting in %ds", self._reconnect_delay
                 )
-                await asyncio.sleep(self._reconnect_delay)
-                self._reconnect_delay = min(self._reconnect_delay * 2, CLOUD_RECONNECT_MAX)
+            if not self._running:
+                break
+            # Backoff before reconnect (both after errors and clean disconnects)
+            await asyncio.sleep(self._reconnect_delay)
+            self._reconnect_delay = min(self._reconnect_delay * 2, CLOUD_RECONNECT_MAX)
 
     async def _connect_once(self) -> None:
         """Single WebSocket connection attempt + message loop."""

--- a/provider/cloud.py
+++ b/provider/cloud.py
@@ -72,7 +72,7 @@ class CloudManager:
                     "Cloud connection error, reconnecting in %ds", self._reconnect_delay
                 )
             if not self._running:
-                break
+                break  # type: ignore[unreachable]
             # Backoff before reconnect (both after errors and clean disconnects)
             await asyncio.sleep(self._reconnect_delay)
             self._reconnect_delay = min(self._reconnect_delay * 2, CLOUD_RECONNECT_MAX)

--- a/provider/device.py
+++ b/provider/device.py
@@ -238,9 +238,9 @@ async def execute_capability_action(
 
         elif action.type == YandexCapabilityType.RANGE and instance == INSTANCE_VOLUME:
             if action.state.relative:
-                target = max(0, min(100, current_volume + int(value)))
+                target = max(0, min(100, current_volume + int(float(value))))
             else:
-                target = max(0, min(100, int(value)))
+                target = max(0, min(100, int(float(value))))
             await mass.players.cmd_volume_set(player_id, target)
             value = target
 
@@ -255,14 +255,26 @@ async def execute_capability_action(
 
         elif action.type == YandexCapabilityType.RANGE and instance == INSTANCE_CHANNEL:
             if action.state.relative:
-                if int(value) > 0:
+                if int(float(value)) > 0:
                     await mass.players.cmd_next_track(player_id)
-                elif int(value) < 0:
+                elif int(float(value)) < 0:
                     await mass.players.cmd_previous_track(player_id)
             # Non-relative channel set is ignored (no concept of channel number in MA)
 
         elif action.type == YandexCapabilityType.MODE and instance == INSTANCE_INPUT_SOURCE:
             player = mass.players.get_player(player_id)
+            if player is None:
+                return CapabilityActionResult(
+                    type=action.type,
+                    state=CapabilityActionResultState(
+                        instance=instance,
+                        action_result=ActionResult(
+                            status="ERROR",
+                            error_code=ERROR_DEVICE_UNREACHABLE,
+                            error_message=f"Player {player_id} not found",
+                        ),
+                    ),
+                )
             p_state = player.state if hasattr(player, "state") else player
             source_list = _get_source_list(p_state)
             source = _mode_to_source(str(value), source_list)
@@ -294,6 +306,18 @@ async def execute_capability_action(
                 ),
             )
 
+    except (ValueError, TypeError):
+        return CapabilityActionResult(
+            type=action.type,
+            state=CapabilityActionResultState(
+                instance=instance,
+                action_result=ActionResult(
+                    status="ERROR",
+                    error_code=ERROR_INVALID_ACTION,
+                    error_message=f"Invalid value for {action.type}/{instance}: {value}",
+                ),
+            ),
+        )
     except Exception:
         _LOGGER.exception("Error executing action %s/%s on %s", action.type, instance, player_id)
         return CapabilityActionResult(

--- a/provider/direct.py
+++ b/provider/direct.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import html as html_module
 import logging
+import secrets
 import time
 import urllib.parse
 import uuid
@@ -182,7 +183,7 @@ class DirectConnectionHandler:
             return False
         auth = request.headers.get("Authorization", "")
         if auth.startswith("Bearer "):
-            return auth[7:] == self._access_token
+            return secrets.compare_digest(auth[7:], self._access_token)
         return False
 
     def _unauthorized_response(self, request_id: str = "") -> web.Response:

--- a/provider/direct.py
+++ b/provider/direct.py
@@ -230,7 +230,7 @@ class DirectConnectionHandler:
 
         try:
             body = await request.json()
-            device_ids = [d["id"] for d in body.get("devices", [])]
+            device_ids = [device_id for d in body.get("devices", []) if (device_id := d.get("id"))]
             states = await handle_devices_query(
                 self._mass, device_ids, exposed_ids=self._exposed_ids
             )

--- a/provider/handlers.py
+++ b/provider/handlers.py
@@ -142,12 +142,18 @@ def parse_action_payload(raw: dict[str, Any]) -> ActionRequestPayload:
     """Parse a raw /user/devices/action message into ActionRequestPayload."""
     devices = []
     for dev_raw in raw.get("payload", raw).get("devices", []):
+        dev_id = dev_raw.get("id")
+        if not dev_id:
+            continue
         capabilities = []
         for cap_raw in dev_raw.get("capabilities", []):
+            cap_type = cap_raw.get("type")
+            if not cap_type:
+                continue
             state_raw = cap_raw.get("state", {})
             capabilities.append(
                 CapabilityAction(
-                    type=cap_raw["type"],
+                    type=cap_type,
                     state=CapabilityActionState(
                         instance=state_raw.get("instance", ""),
                         value=state_raw.get("value"),
@@ -155,7 +161,7 @@ def parse_action_payload(raw: dict[str, Any]) -> ActionRequestPayload:
                     ),
                 )
             )
-        devices.append(DeviceAction(id=dev_raw["id"], capabilities=capabilities))
+        devices.append(DeviceAction(id=dev_id, capabilities=capabilities))
     return ActionRequestPayload(devices=devices)
 
 

--- a/provider/notifier.py
+++ b/provider/notifier.py
@@ -140,9 +140,16 @@ class StateNotifier:
         self._flush_handle = None
         if not self._pending:
             return
-        devices = list(self._pending.values())
-        self._pending.clear()
-        await self._send_state_callback(devices)
+        pending = self._pending
+        self._pending = {}
+        devices = list(pending.values())
+        try:
+            await self._send_state_callback(devices)
+        except Exception:
+            # Re-queue failed devices (merge back, newer wins)
+            self._pending = pending | self._pending
+            self._schedule_flush()
+            raise
 
     # -----------------------------------------------------------------------
     # State reporting

--- a/provider/plugin.py
+++ b/provider/plugin.py
@@ -263,7 +263,9 @@ class YandexSmartHomePlugin(PluginProvider):
                 return build_response(request_id, asdict(device_list))
 
             if normalized == "/user/devices/query":
-                device_ids = [d["id"] for d in message.get("devices", [])]
+                device_ids = [
+                    device_id for d in message.get("devices", []) if (device_id := d.get("id"))
+                ]
                 states = await handle_devices_query(
                     self.mass, device_ids, exposed_ids=self._exposed_ids
                 )

--- a/provider/plugin.py
+++ b/provider/plugin.py
@@ -198,6 +198,10 @@ class YandexSmartHomePlugin(PluginProvider):
             )
             return
 
+        if not self._direct_client_secret:
+            self.logger.error("Direct mode requires a client secret for OAuth account linking")
+            return
+
         self._user_id = self._instance_name
 
         def _on_token_created(token: str) -> None:


### PR DESCRIPTION
Additional fixes for Copilot review comments on music-assistant/server PR #3615:

- **cloud.py**: Avoid sending `json=None` in `register_cloud_instance` — omit json kwarg entirely when no platform
- **plugin.py**: Defensive `device_ids` parsing with `.get('id')` and walrus operator
- **direct.py**: Same defensive parsing in `_handle_query`
- **notifier.py**: Re-queue pending state updates on flush failure instead of dropping them