### PR TITLE
chore(deps): bump ya-passport-auth to 1.5.0

### DIFF
--- a/provider/manifest.json
+++ b/provider/manifest.json
@@ -8,7 +8,7 @@
     "[dext0r/yandex_smart_home](https://github.com/dext0r/yandex_smart_home)"
   ],
   "requirements": [
-    "ya-passport-auth==1.4.1",
+    "ya-passport-auth==1.5.0",
     "ya-dialogs-api==2.4.0"
   ],
   "documentation": "https://github.com/trudenboy/ma-provider-yandex-smarthome",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -39,7 +39,7 @@ def test_manifest_valid() -> None:
     assert data["multi_instance"] is False
     assert data["builtin"] is False
     assert isinstance(data["requirements"], list)
-    assert "ya-passport-auth==1.3.0" in data["requirements"]
+    assert "ya-passport-auth==1.5.0" in data["requirements"]
 
 
 def test_manifest_has_codeowners() -> None:


### PR DESCRIPTION
Phase 0 of the auth-unification plan: single exact `ya-passport-auth==1.5.0` across all yandex providers (companion to trudenboy/ma-provider-tools#106).

- `manifest.json`: 1.4.1 → 1.5.0.
- `tests/test_basic.py::test_manifest_valid`: the assertion still pinned `==1.3.0` — it was not updated when commit 7a2e04b bumped the manifest to 1.4.1, so it has been red against dev since then. Updated to assert the new pin.
- `uv.lock` NOT regenerated: a full re-lock currently fails on a pre-existing conflict — this repo's `requires-python >=3.12` (synced from ma-provider-tools `python_version`) vs music-assistant@dev requiring `>=3.14`. Needs a separate `python_version` bump in ma-provider-tools `providers.yml`.

226 tests pass locally (venv with ya-passport-auth 1.5.0 + hass-client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)