### PR TITLE
refactor(auth): adopt the shared ya_passport_auth.ma layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.1.11] - 2026-07-09
+
+### Changed
+
+- The Yandex Passport sign-in page for skill auto-creation now comes from the shared `ya-passport-auth[ma]` layer used by all Music Assistant yandex providers: Russian/English localization, dark-theme support, tap-to-copy code, an honest countdown and clear terminal states explaining why a sign-in failed.
+- The sign-in step returns the moment the outcome is known instead of pausing for a grace period; the page keeps polling in the background and closes itself.
+- Transient Yandex Passport failures (network, rate limiting) during sign-in now surface as "temporarily unavailable" instead of a login failure. The cached-token fast path is unchanged.
+
 ## [2.1.10] - 2026-05-12
 
 ### Changed

--- a/conftest.py
+++ b/conftest.py
@@ -146,6 +146,35 @@ class _MassEvent:
 
 _ensure_module("music_assistant_models.event", {"MassEvent": _MassEvent})
 
+
+# music_assistant_models.errors — needed by ya_passport_auth.ma (the shared
+# auth layer imports the MA error types at module level).
+class _MusicAssistantError(Exception):
+    pass
+
+
+class _LoginFailed(_MusicAssistantError):
+    pass
+
+
+class _ResourceTemporarilyUnavailable(_MusicAssistantError):
+    pass
+
+
+class _InvalidDataError(_MusicAssistantError):
+    pass
+
+
+_ensure_module(
+    "music_assistant_models.errors",
+    {
+        "MusicAssistantError": _MusicAssistantError,
+        "LoginFailed": _LoginFailed,
+        "ResourceTemporarilyUnavailable": _ResourceTemporarilyUnavailable,
+        "InvalidDataError": _InvalidDataError,
+    },
+)
+
 # ---------------------------------------------------------------------------
 # 2. Mock music_assistant server modules
 # ---------------------------------------------------------------------------

--- a/provider/ma_authenticator.py
+++ b/provider/ma_authenticator.py
@@ -1,34 +1,30 @@
 """Music-Assistant Device-Flow authenticator for ya-dialogs-api.
 
-Adapter that wraps :class:`ya_passport_auth.PassportClient` Device Flow
-behind the :data:`ya_dialogs_api.AuthenticatorCM` Protocol — a no-arg
+Adapter that wraps the shared ``ya_passport_auth.ma`` Device Flow behind
+the :data:`ya_dialogs_api.AuthenticatorCM` Protocol — a no-arg
 async-context-manager factory yielding an authorized
 ``aiohttp.ClientSession``.
 
 UX:
-- Hosts a temporary HTML activation page on ``mass.webserver`` showing the
-  Device Code prominently (Yandex's ya.ru/device strips query params on
-  the redirect-to-login, so we cannot pre-fill the code there).
-- Opens the page in a popup via ``music_assistant.helpers.auth.AuthenticationHelper``.
-- After the user enters the code at ya.ru/device, the page polls a status
-  endpoint and self-closes on success.
+- The MA-hosted activation page (localized, tap-to-copy code, honest
+  countdown, failure reasons) comes from ``ya_passport_auth.ma``; Yandex's
+  ya.ru/device strips query params on the redirect-to-login, so the code
+  cannot be pre-filled there.
+- The page opens in a popup via ``music_assistant.helpers.auth.AuthenticationHelper``.
 
 Cache fast-path:
 - If a valid cached ``x_token`` is provided, we skip Device Flow entirely
   and call ``refresh_passport_cookies`` directly. On any failure during
   refresh we fall back to a fresh Device Flow.
 
-Body is ported verbatim from the deleted ``provider/auto_skill.py:_default_authenticator``;
-the only structural change is the wrapper — async-iterator → ``@asynccontextmanager``
-to match the lib's :data:`AuthenticatorCM` Protocol.
-
-Pattern originally adapted from ``ma-provider-yandex-station/provider/auth.py``.
+The dialogs API session keeps its own :class:`ya_passport_auth.PassportClient`
+(with ``dialogs.yandex.ru`` in the allowed hosts) — the login flow only
+supplies the credentials; the cookies are then minted into this client.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import re
 from contextlib import asynccontextmanager
@@ -48,23 +44,10 @@ _LOGGER = logging.getLogger(__name__)
 # Hard cap on how long we'll wait for the user to enter the code.
 DEVICE_FLOW_TIMEOUT_SECONDS = 300.0
 
-_DEVICE_CODE_PAGE_PATH = "/yandex_smarthome/device_code"
-# Keep the intermediate HTML page alive long enough for the browser to
-# observe the done/failed state transition. The page polls every 2s
-# (see _build_device_code_page → setTimeout(pollStatus, 2000)), so we
-# need at least one full poll interval + RTT margin after flipping the
-# server-side state, otherwise the route gets unregistered before the
-# page can fetch the final state and self-close.
-_POST_AUTH_GRACE_SECONDS = 3
-# Server-suggested interval from Yandex is 5s (RFC 8628) but after the
-# user has confirmed the code we want to detect it promptly; 2s is the
-# RFC-recommended minimum. If Yandex returns SLOW_DOWN, ya-passport-auth
-# bumps the interval automatically.
-_DEVICE_FLOW_POLL_INTERVAL = 2.0
 _SAFE_SESSION_ID_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
 
 
-def make_authenticator(  # noqa: PLR0915
+def make_authenticator(
     *,
     mass: MusicAssistant,
     session_id: str,
@@ -78,9 +61,9 @@ def make_authenticator(  # noqa: PLR0915
     context manager. On ``__aenter__`` it either:
 
     1. Reuses ``cached_x_token`` (``refresh_passport_cookies`` fast-path), or
-    2. Runs the full Device Flow: registers an HTML activation page on
-       ``mass.webserver``, opens it via ``AuthenticationHelper(mass, session_id)``,
-       polls Yandex Passport, then refreshes passport cookies.
+    2. Runs the full Device Flow via the shared ``ya_passport_auth.ma``
+       layer (MA-hosted activation page + ``AuthenticationHelper`` popup),
+       then refreshes passport cookies.
 
     After a successful Device Flow, ``on_token_obtained(x_token_str)`` is
     called so the caller can persist the new token for the next run.
@@ -108,14 +91,12 @@ def make_authenticator(  # noqa: PLR0915
         raise ValueError(msg)
 
     @asynccontextmanager
-    async def _cm() -> AsyncIterator[aiohttp.ClientSession]:  # noqa: PLR0915
+    async def _cm() -> AsyncIterator[aiohttp.ClientSession]:
         # Imports kept inline so the module can be imported without MA in test envs.
-        from aiohttp import web  # noqa: PLC0415
         from ya_passport_auth import ClientConfig, PassportClient  # noqa: PLC0415
         from ya_passport_auth.config import DEFAULT_ALLOWED_HOSTS  # noqa: PLC0415
         from ya_passport_auth.credentials import SecretStr as PpSecretStr  # noqa: PLC0415
-
-        from music_assistant.helpers.auth import AuthenticationHelper  # noqa: PLC0415
+        from ya_passport_auth.ma import DevicePageConfig, run_device_flow  # noqa: PLC0415
 
         allowed = DEFAULT_ALLOWED_HOSTS | frozenset({"dialogs.yandex.ru"})
         config = ClientConfig(allowed_hosts=allowed)
@@ -141,77 +122,27 @@ def make_authenticator(  # noqa: PLR0915
                         exc,
                     )
 
-            # Device Flow path
-            device_session = await client.start_device_login()
-            # Don't log user_code — it's a time-limited credential and writing
-            # it to shared log backends would leak access.
-            _LOGGER.info(
-                "device flow started — verification_url=%s",
-                device_session.verification_url,
-            )
-
-            page_path = f"{_DEVICE_CODE_PAGE_PATH}/{session_id}"
-            status_path = f"{page_path}/status"
-            base_url = str(mass.webserver.base_url).rstrip("/")
-            status_url = f"{base_url}{status_path}"
-            page_url = f"{base_url}{page_path}"
-            state = {"value": "pending"}
-
-            page_html = _build_device_code_page(
-                device_session.user_code,
-                device_session.verification_url,
-                status_url,
-            )
-
-            async def _serve_page(_request: web.Request) -> web.Response:
-                return web.Response(
-                    text=page_html,
-                    content_type="text/html",
-                    charset="utf-8",
-                    headers={
-                        "Cache-Control": "no-store",
-                        "Pragma": "no-cache",
-                        "Expires": "0",
-                    },
-                )
-
-            async def _serve_status(_request: web.Request) -> web.Response:
-                return web.json_response(
-                    {"state": state["value"]},
-                    headers={"Cache-Control": "no-store"},
-                )
-
-            mass.webserver.register_dynamic_route(page_path, _serve_page, "GET")
-            mass.webserver.register_dynamic_route(status_path, _serve_status, "GET")
+            # Device Flow via the shared layer: it hosts the activation page
+            # under /yandex_smarthome/device_code/<session_id>, opens the
+            # popup and polls until confirmation.
             _LOGGER.warning(
-                "auto-skill: device-code popup URL %s (path=%s) "
-                "— if the popup does not open or points at an unreachable "
-                "address, open the path directly in your browser (the page "
-                "displays the user_code) or fix Settings → Core → Webserver "
-                "→ Base URL",
-                page_url,
-                page_path,
+                "auto-skill: opening device-code popup at "
+                "/yandex_smarthome/device_code/%s — if the popup does not "
+                "open or points at an unreachable address, open the path "
+                "directly in your browser (the page displays the user_code) "
+                "or fix Settings → Core → Webserver → Base URL",
+                session_id,
             )
-            try:
-                async with AuthenticationHelper(mass, session_id) as auth_helper:
-                    auth_helper.send_url(page_url)
-                    try:
-                        creds = await client.poll_device_until_confirmed(
-                            device_session,
-                            total_timeout=timeout,
-                            poll_interval=_DEVICE_FLOW_POLL_INTERVAL,
-                        )
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception:
-                        state["value"] = "failed"
-                        await asyncio.sleep(_POST_AUTH_GRACE_SECONDS)
-                        raise
-                    state["value"] = "done"
-                    await asyncio.sleep(_POST_AUTH_GRACE_SECONDS)
-            finally:
-                mass.webserver.unregister_dynamic_route(page_path, "GET")
-                mass.webserver.unregister_dynamic_route(status_path, "GET")
+            result = await run_device_flow(
+                mass,
+                session_id,
+                DevicePageConfig(
+                    domain="yandex_smarthome",
+                    title={"en": "Login to Yandex Smart Home", "ru": "Вход в Яндекс Умный Дом"},
+                ),
+                total_timeout=timeout,
+            )
+            creds = result.credentials
 
             await client.refresh_passport_cookies(creds.x_token)
 
@@ -230,138 +161,3 @@ def make_authenticator(  # noqa: PLR0915
             yield client._session
 
     return _cm
-
-
-def _build_device_code_page(user_code: str, verification_url: str, status_url: str) -> str:
-    """Render the HTML page shown during Device Flow login.
-
-    Yandex's ya.ru/device page does not pre-fill from query params and
-    strips them on redirect-to-login, so the only reliable way to show
-    the code is to host our own page in MA's webserver that displays
-    the code prominently and opens ya.ru/device in a new tab.
-
-    Pattern copied from ``ma-provider-yandex-station/provider/auth.py``.
-    """
-    import html  # noqa: PLC0415
-
-    safe_code = html.escape(user_code)
-    safe_url = html.escape(verification_url, quote=True)
-    safe_status_url = json.dumps(status_url).replace("</", "<\\/")
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Yandex Smart Home — Device Code</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-        :root {{ color-scheme: light; }}
-        body {{
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-            margin: 0; padding: 2rem 1rem;
-            display: flex; align-items: center; justify-content: center;
-            min-height: 100vh; box-sizing: border-box;
-            background: #f5f5f7; color: #1d1d1f;
-        }}
-        .card {{
-            background: #ffffff; color: #1d1d1f;
-            border-radius: 14px; padding: 2rem;
-            max-width: 28rem; width: 100%;
-            box-shadow: 0 4px 20px rgba(0,0,0,.08);
-            text-align: center;
-        }}
-        h1 {{ margin: 0 0 .5rem; font-size: 1.25rem; }}
-        p {{ margin: .5rem 0 1.25rem; color: #4a4a52; line-height: 1.45; }}
-        #code {{
-            display: inline-block;
-            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-            font-size: 2rem; font-weight: 600; letter-spacing: .15em;
-            padding: .75rem 1.25rem; border-radius: 10px;
-            background: #f2f2f7; color: #1d1d1f;
-            user-select: all;
-        }}
-        button, .btn {{
-            display: inline-block; margin-top: 1.5rem; padding: .75rem 1.5rem;
-            font-size: 1rem; font-weight: 600; text-decoration: none;
-            border: none; border-radius: 10px; cursor: pointer;
-            background: #ffcc00; color: #1d1d1f;
-        }}
-        button:hover, .btn:hover {{ background: #ffd633; }}
-        #copy {{
-            margin-top: .75rem; background: transparent; color: #1d1d1f;
-            border: 1px solid #c8c8cd; padding: .4rem 1rem;
-            font-size: .85rem; font-weight: 400;
-        }}
-        #copy:hover {{ background: #f2f2f7; }}
-    </style>
-</head>
-<body>
-    <div class="card" id="card">
-        <h1>Authorise Music Assistant for skill creation</h1>
-        <p>Open the link below, log in to your Yandex account, and enter this code.</p>
-        <div id="code">{safe_code}</div>
-        <div>
-            <button id="copy" type="button">Copy code</button>
-        </div>
-        <a class="btn" href="{safe_url}" target="_blank" rel="noopener">Continue to Yandex</a>
-    </div>
-    <script>
-        const copyButton = document.getElementById('copy');
-        const codeElement = document.getElementById('code');
-        const card = document.getElementById('card');
-        const statusUrl = {safe_status_url};
-
-        function selectCodeForManualCopy() {{
-            if (!codeElement) return;
-            const selection = window.getSelection();
-            if (!selection) return;
-            const range = document.createRange();
-            range.selectNodeContents(codeElement);
-            selection.removeAllRanges();
-            selection.addRange(range);
-            if (copyButton) copyButton.textContent = 'Press Ctrl/Cmd+C';
-        }}
-
-        copyButton?.addEventListener('click', async function() {{
-            const code = codeElement?.textContent?.trim();
-            if (!code) return;
-            if (!navigator.clipboard?.writeText) {{
-                selectCodeForManualCopy();
-                return;
-            }}
-            try {{
-                await navigator.clipboard.writeText(code);
-                this.textContent = 'Copied';
-            }} catch {{
-                selectCodeForManualCopy();
-            }}
-        }});
-
-        function showResult(title, message) {{
-            card.innerHTML = '<h1>' + title + '</h1><p>' + message + '</p>';
-        }}
-
-        async function pollStatus() {{
-            try {{
-                const r = await fetch(statusUrl, {{ cache: 'no-store' }});
-                if (r.ok) {{
-                    const data = await r.json();
-                    if (data.state === 'done') {{
-                        showResult('Authorisation successful', 'You can close this window.');
-                        setTimeout(() => {{ try {{ window.close(); }} catch (e) {{}} }}, 300);
-                        return;
-                    }}
-                    if (data.state === 'failed') {{
-                        showResult(
-                            'Authorisation failed',
-                            'Return to Music Assistant and try again.'
-                        );
-                        return;
-                    }}
-                }}
-            }} catch (e) {{ /* network hiccup — retry */ }}
-            setTimeout(pollStatus, 2000);
-        }}
-        setTimeout(pollStatus, 2000);
-    </script>
-</body>
-</html>"""

--- a/provider/manifest.json
+++ b/provider/manifest.json
@@ -8,7 +8,7 @@
     "[dext0r/yandex_smart_home](https://github.com/dext0r/yandex_smart_home)"
   ],
   "requirements": [
-    "ya-passport-auth==1.5.0",
+    "ya-passport-auth[ma]==1.6.0",
     "ya-dialogs-api==2.4.0"
   ],
   "documentation": "https://github.com/trudenboy/ma-provider-yandex-smarthome",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -39,7 +39,7 @@ def test_manifest_valid() -> None:
     assert data["multi_instance"] is False
     assert data["builtin"] is False
     assert isinstance(data["requirements"], list)
-    assert "ya-passport-auth==1.5.0" in data["requirements"]
+    assert "ya-passport-auth[ma]==1.6.0" in data["requirements"]
 
 
 def test_manifest_has_codeowners() -> None:

--- a/tests/test_ma_authenticator.py
+++ b/tests/test_ma_authenticator.py
@@ -7,14 +7,30 @@ is fast, deterministic, and unit-testable without stubbing those upstream
 packages:
 
 - session_id validation (the only synchronous gate inside ``make_authenticator``)
-- HTML activation page rendering (escaping, JS payload safety)
+- HTML activation page rendering (escaping, JS payload safety) — the page now
+  comes from ``ya_passport_auth.ma``; the escaping contract is re-asserted
+  here against this provider's page config so a library regression is caught
+  at the consumer.
 """
 
 from __future__ import annotations
 
 import pytest
+from ya_passport_auth.ma import DevicePageConfig, build_device_code_page
 
-from provider.ma_authenticator import _build_device_code_page, make_authenticator
+from provider.ma_authenticator import make_authenticator
+
+_PAGE = DevicePageConfig(domain="yandex_smarthome")
+
+
+def _build_device_code_page(*, user_code: str, verification_url: str, status_url: str) -> str:
+    return build_device_code_page(
+        user_code=user_code,
+        verification_url=verification_url,
+        status_url=status_url,
+        expires_in=300,
+        strings=_PAGE.strings_for("en"),
+    )
 
 
 class TestSessionIdValidation:


### PR DESCRIPTION
Phase 2D of the auth-unification plan (companions: ya-passport-auth#55, music#204, station#97, ynison#97, alice#66; needs trudenboy/ma-provider-tools#107 distributed for CI).

`make_authenticator` keeps its `AuthenticatorCM` contract, cached-x_token fast path and `on_token_obtained` callback; the Device Flow internals (activation page + routes + popup + polling) now come from `ya-passport-auth[ma]==1.6.0` — the page gains l10n, dark theme, tap-to-copy, honest countdown and failure reasons; blocking grace sleeps are gone (30 s deferred teardown). The dialogs-API session keeps its own `PassportClient` with `dialogs.yandex.ru` allowed; the flow only supplies credentials.

Deltas: flow errors surface as MA types (`LoginFailed` / `ResourceTemporarilyUnavailable`) — no caller had library-specific handling; custom 2 s poll interval yields to the RFC 8628 server-suggested one.

226 tests pass; ruff clean. Note: this repo is inlined upstream — the change flows there with the next sync. No spec required: `refactor:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)