### PR TITLE
feat(auth): borrow the Yandex account from a linked Yandex Music provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-07-09
+
+### Added
+
+- **Yandex account source**: skill auto-create can now borrow the Yandex account of a configured Yandex Music provider instead of running its own Device Flow — one sign-in for the whole household, no device-code popup. Pick the source in the settings dropdown; "Use own credentials" remains the default and behaves exactly as before. When borrowing, nothing is stored or rotated by this provider, and a missing or rejected linked account reports "re-authenticate the Yandex Music provider" in the auto-create status instead of silently falling back to an own sign-in.
+
 ## [2.1.11] - 2026-07-09
 
 ### Changed

--- a/conftest.py
+++ b/conftest.py
@@ -117,10 +117,23 @@ class _ConfigEntry:
 
 
 class _ConfigValueOption:
-    def __init__(self, title="", value=None):
-        self.title = title
+    # Mirrors music_assistant_models.config_entries.ConfigValueOption:
+    # ``value`` first, optional ``title``.
+    def __init__(self, value=None, title=None):
         self.value = value
+        self.title = title
 
+
+class _ProviderType(_StrEnum):
+    MUSIC = "music"
+    PLAYER = "player"
+    METADATA = "metadata"
+    PLUGIN = "plugin"
+
+
+_prov_enums = sys.modules.get("music_assistant_models.enums")
+if _prov_enums is not None and not hasattr(_prov_enums, "ProviderType"):
+    _prov_enums.ProviderType = _ProviderType
 
 _ensure_module(
     "music_assistant_models.config_entries",

--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -38,6 +38,11 @@ from ya_dialogs_api import (
     load_artifacts,
     load_default_logo_bytes,
 )
+from ya_passport_auth.ma import (
+    BORROW_SOURCE_OWN,
+    BorrowedCredentialSource,
+    list_yandex_music_instances,
+)
 
 from ._smarthome_auto_create import derive_smart_home_urls, resolve_base_url
 from .cloud import get_cloud_otp, register_cloud_instance
@@ -60,6 +65,7 @@ from .constants import (
     CONF_INSTANCE_NAME,
     CONF_SKILL_ID,
     CONF_SKILL_TOKEN,
+    CONF_YM_INSTANCE,
     CONNECTION_TYPE_CLOUD,
     CONNECTION_TYPE_CLOUD_PLUS,
     CONNECTION_TYPE_DIRECT,
@@ -238,13 +244,36 @@ async def _run_auto_create_action(
     async def _persist_artifacts(a: SkillCreationArtifacts) -> None:
         values[CONF_AUTO_CREATE_ARTIFACTS] = dump_artifacts(a)
 
-    cached = _resolve_cached_x_token(mass, instance_id, values) or None
-    authenticator = make_authenticator(
-        mass=mass,
-        session_id=session_id,
-        cached_x_token=cached,
-        on_token_obtained=_cache_x_token,
-    )
+    # Yandex account source: borrow the linked yandex_music instance's
+    # x_token read-only (no Device Flow fallback, no persistence into this
+    # provider's config), or run the own cached-token/Device Flow path.
+    ym_selected = str(values.get(CONF_YM_INSTANCE) or BORROW_SOURCE_OWN)
+    borrowing = ym_selected != BORROW_SOURCE_OWN
+    if borrowing:
+        try:
+            _, borrowed_x = BorrowedCredentialSource(mass, ym_selected).read_tokens()
+        except Exception as exc:
+            new_artifacts = dataclasses.replace(
+                artifacts, state=SkillCreationState.FAILED, last_error=str(exc)
+            )
+            values[CONF_AUTO_CREATE_ARTIFACTS] = dump_artifacts(new_artifacts)
+            _LOGGER.warning("auto-create borrow source unavailable: %s", exc)
+            return
+        authenticator = make_authenticator(
+            mass=mass,
+            session_id=session_id,
+            cached_x_token=borrowed_x.get_secret() if borrowed_x else None,
+            on_token_obtained=None,
+            allow_device_flow=False,
+        )
+    else:
+        cached = _resolve_cached_x_token(mass, instance_id, values) or None
+        authenticator = make_authenticator(
+            mass=mass,
+            session_id=session_id,
+            cached_x_token=cached,
+            on_token_obtained=_cache_x_token,
+        )
 
     try:
         new_artifacts = await auto_create_skill(
@@ -358,6 +387,16 @@ async def get_config_entries(
     if values is None:
         values = {}
 
+    # Yandex account source: normalize a stale selection back to own so
+    # the auto-create flow doesn't chase a removed instance.
+    ym_instances = list_yandex_music_instances(mass)
+    ym_selected = str(values.get(CONF_YM_INSTANCE) or BORROW_SOURCE_OWN)
+    if ym_selected != BORROW_SOURCE_OWN and ym_selected not in {
+        inst_id for inst_id, _ in ym_instances
+    }:
+        ym_selected = BORROW_SOURCE_OWN
+        values[CONF_YM_INSTANCE] = BORROW_SOURCE_OWN
+
     connection_type = str(values.get(CONF_CONNECTION_TYPE, CONNECTION_TYPE_CLOUD))
     is_cloud = connection_type == CONNECTION_TYPE_CLOUD
     is_cloud_plus = connection_type == CONNECTION_TYPE_CLOUD_PLUS
@@ -439,7 +478,7 @@ async def get_config_entries(
     elif is_direct:
         entries.extend(_direct_mode_entries(mass, instance_id, values, artifacts, skill_token_set))
 
-    entries.extend(_common_tail_entries(player_options, playlist_options, values))
+    entries.extend(_common_tail_entries(player_options, playlist_options, values, ym_instances))
     return tuple(entries)
 
 
@@ -819,6 +858,7 @@ def _common_tail_entries(
     player_options: list[ConfigValueOption],
     playlist_options: list[ConfigValueOption],
     values: dict[str, ConfigValueType],
+    ym_instances: list[tuple[str, str]],
 ) -> list[ConfigEntry]:
     """Player filter + hidden round-trip fields shared by every mode."""
     return [
@@ -901,6 +941,26 @@ def _common_tail_entries(
             hidden=True,
             required=False,
             value=(cast("str", values.get(CONF_AUTO_CREATE_SESSION_ID)) if values else None),
+        ),
+        ConfigEntry(
+            key=CONF_YM_INSTANCE,
+            type=ConfigEntryType.STRING,
+            label="Yandex account source",
+            description=(
+                "Borrow the Yandex account of a configured Yandex Music "
+                "provider for skill auto-create (single sign-in, no Device "
+                "Flow popup) or use this provider's own sign-in. When "
+                "borrowing, nothing is stored or rotated by this provider."
+            ),
+            options=[
+                *(
+                    ConfigValueOption(inst_id, f"Yandex Music: {name}")
+                    for inst_id, name in ym_instances
+                ),
+                ConfigValueOption(BORROW_SOURCE_OWN, "Use own credentials (default)"),
+            ],
+            default_value=BORROW_SOURCE_OWN,
+            required=False,
         ),
         # Cached Yandex Passport x_token — populated after the first
         # successful auto-create Device Flow and reused on subsequent

--- a/provider/constants.py
+++ b/provider/constants.py
@@ -36,6 +36,11 @@ CONF_ACTION_REGISTER = "register_cloud"
 CONF_ACTION_GET_OTP = "get_otp"
 CONF_ACTION_AUTO_CREATE = "auto_create_skill"
 
+# Yandex account source: instance_id of a linked yandex_music provider to
+# borrow the x_token from, or the shared "__own__" sentinel for this
+# provider's own Device Flow (key name matches the other yandex providers).
+CONF_YM_INSTANCE = "ym_instance"
+
 # ---------------------------------------------------------------------------
 # Connection types
 # ---------------------------------------------------------------------------

--- a/provider/ma_authenticator.py
+++ b/provider/ma_authenticator.py
@@ -54,6 +54,7 @@ def make_authenticator(
     timeout: float = DEVICE_FLOW_TIMEOUT_SECONDS,
     cached_x_token: str | None = None,
     on_token_obtained: Callable[[str], None] | None = None,
+    allow_device_flow: bool = True,
 ) -> AuthenticatorCM:
     """Build an :data:`AuthenticatorCM` for ``ya_dialogs_api.auto_create_skill``.
 
@@ -83,6 +84,11 @@ def make_authenticator(
         ``x_token`` (plain ``str``, unwrapped from ``SecretStr``)
         after a successful Device Flow. Use to persist into MA config
         so the next run can use the cache.
+    :param allow_device_flow: When False (borrowed credentials from a
+        linked Yandex Music instance), a missing or rejected
+        ``cached_x_token`` raises ``LoginFailed`` with re-authentication
+        guidance instead of falling back to a Device Flow — a fallback
+        would create the second token family borrow mode exists to avoid.
     :raises ValueError: ``session_id`` doesn't match the safe
         character set.
     """
@@ -116,11 +122,28 @@ def make_authenticator(
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:
+                    if not allow_device_flow:
+                        from music_assistant_models.errors import LoginFailed  # noqa: PLC0415
+
+                        raise LoginFailed(
+                            "The linked Yandex Music account's session token was "
+                            "rejected by Yandex. Re-authenticate the Yandex Music "
+                            "provider and retry."
+                        ) from exc
                     _LOGGER.info(
                         "auto-skill: cached x_token rejected (%s) — "
                         "falling back to fresh Device Flow",
                         exc,
                     )
+
+            if not allow_device_flow:
+                from music_assistant_models.errors import LoginFailed  # noqa: PLC0415
+
+                raise LoginFailed(
+                    "The linked Yandex Music account has no session token. "
+                    "Authenticate the Yandex Music provider (with Remember "
+                    "session enabled) and retry."
+                )
 
             # Device Flow via the shared layer: it hosts the activation page
             # under /yandex_smarthome/device_code/<session_id>, opens the

--- a/provider/manifest.json
+++ b/provider/manifest.json
@@ -8,7 +8,7 @@
     "[dext0r/yandex_smart_home](https://github.com/dext0r/yandex_smart_home)"
   ],
   "requirements": [
-    "ya-passport-auth[ma]==1.6.0",
+    "ya-passport-auth[ma]==1.7.0",
     "ya-dialogs-api==2.4.0"
   ],
   "documentation": "https://github.com/trudenboy/ma-provider-yandex-smarthome",

--- a/specs/inprogress/0001-borrow-account-source.md
+++ b/specs/inprogress/0001-borrow-account-source.md
@@ -1,0 +1,54 @@
+---
+id: "0001"
+title: "Borrow the Yandex account from a linked Yandex Music provider"
+size: S
+status: inprogress
+priority: P1
+effort_minutes: 10
+feature_id:
+---
+
+## Problem Statement
+
+Skill auto-create runs its own Yandex Passport Device Flow and caches its
+own x_token, even when the user already signed into Yandex through the
+Yandex Music provider — a second login and a second token for one account.
+
+## Solution Summary
+
+A "Yandex account source" dropdown (same option the other yandex providers
+offer): pick a configured Yandex Music instance to borrow its x_token for
+skill auto-create, or keep "Use own credentials". When borrowing, the
+Device Flow never runs — the borrowed token authenticates the dialogs
+session read-only (never persisted into this provider's config, never
+rotated), and a rejected/unavailable source reports "re-authenticate the
+Yandex Music provider" instead of silently falling back to an own Device
+Flow.
+
+## Acceptance Criteria
+
+1. The settings form shows the source dropdown listing every configured
+   Yandex Music instance plus "Use own credentials (default)"; a stale
+   selection normalizes back to own.
+2. With a source selected, auto-create authenticates with the borrowed
+   x_token and never opens the Device Flow popup.
+3. The borrowed token is never written into this provider's `auth_x_token`
+   storage.
+4. A linked instance that is missing or holds no x_token fails the
+   auto-create step with an actionable message in the status area (no
+   Device Flow fallback).
+5. With "Use own credentials", behavior is byte-identical to today
+   (cached-token fast path, Device Flow fallback, token persistence).
+
+## Test Plan
+
+- `test_dropdown_lists_instances_and_own` — options and default.
+- `test_stale_selection_normalizes_to_own`.
+- `test_authenticator_no_device_flow_when_disallowed` — cached token
+  rejected + `allow_device_flow=False` → LoginFailed mentioning Yandex
+  Music, Device Flow never started.
+- `test_auto_create_borrow_uses_ym_token_without_persistence` — the
+  authenticator receives the YM x_token; `on_token_obtained` absent;
+  own storage untouched.
+- `test_auto_create_borrow_source_error_lands_in_artifacts` — missing YM
+  instance → artifacts FAILED with actionable message.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -39,7 +39,7 @@ def test_manifest_valid() -> None:
     assert data["multi_instance"] is False
     assert data["builtin"] is False
     assert isinstance(data["requirements"], list)
-    assert "ya-passport-auth[ma]==1.6.0" in data["requirements"]
+    assert "ya-passport-auth[ma]==1.7.0" in data["requirements"]
 
 
 def test_manifest_has_codeowners() -> None:

--- a/tests/test_borrow_source.py
+++ b/tests/test_borrow_source.py
@@ -1,0 +1,147 @@
+"""Borrow mode: skill auto-create uses a linked Yandex Music account.
+
+Covers spec 0001 — account-source dropdown, no-Device-Flow semantics for a
+borrowed token, read-only use, and actionable failure reporting.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest import mock
+
+import pytest
+from music_assistant_models.errors import LoginFailed
+from ya_passport_auth.ma import BORROW_SOURCE_OWN
+
+from provider import _run_auto_create_action, get_config_entries
+from provider.constants import (
+    CONF_AUTH_X_TOKEN,
+    CONF_AUTO_CREATE_ARTIFACTS,
+    CONF_YM_INSTANCE,
+)
+from provider.ma_authenticator import make_authenticator
+
+
+def _make_mass(instances: dict[str, str] | None = None) -> mock.MagicMock:
+    from music_assistant_models.enums import ProviderType
+
+    mass = mock.MagicMock()
+    mass.config.get.return_value = {
+        inst_id: {"domain": "yandex_music", "name": name}
+        for inst_id, name in (instances or {}).items()
+    }
+    owner = mock.MagicMock()
+    owner.domain = "yandex_music"
+    owner.type = ProviderType.MUSIC
+    owner.config.get_value = lambda key: {"x_token": "test-x-ym"}.get(key)
+    mass.get_provider.return_value = owner
+    mass.webserver.base_url = "http://ma.local:8095"
+    return mass
+
+
+def _by_key(entries: tuple[Any, ...]) -> dict[str, Any]:
+    return {e.key: e for e in entries}
+
+
+class TestDropdown:
+    async def test_dropdown_lists_instances_and_own(self) -> None:
+        mass = _make_mass({"ym-a": "Main", "ym-b": "Second"})
+        entries = await get_config_entries(mass, values={})
+        source = _by_key(entries)[CONF_YM_INSTANCE]
+        option_values = [opt.value for opt in source.options]
+        assert BORROW_SOURCE_OWN in option_values
+        assert "ym-a" in option_values
+        assert "ym-b" in option_values
+
+    async def test_stale_selection_normalizes_to_own(self) -> None:
+        mass = _make_mass({"ym-a": "Main"})
+        values: dict[str, Any] = {CONF_YM_INSTANCE: "removed"}
+        await get_config_entries(mass, values=values)
+        assert values[CONF_YM_INSTANCE] == BORROW_SOURCE_OWN
+
+
+class TestAuthenticatorNoDeviceFlow:
+    async def test_no_device_flow_when_disallowed(self) -> None:
+        # Rejected borrowed token + allow_device_flow=False must fail with
+        # guidance, never start a Device Flow.
+        mass = mock.MagicMock()
+        authenticator = make_authenticator(
+            mass=mass,
+            session_id="s1",
+            cached_x_token="test-x-borrowed",
+            allow_device_flow=False,
+        )
+        fake_client = mock.MagicMock()
+        fake_client.refresh_passport_cookies = mock.AsyncMock(side_effect=RuntimeError("rejected"))
+        fake_client.start_device_login = mock.AsyncMock()
+        cm = mock.MagicMock()
+        cm.__aenter__ = mock.AsyncMock(return_value=fake_client)
+        cm.__aexit__ = mock.AsyncMock(return_value=False)
+        with (
+            mock.patch("ya_passport_auth.PassportClient.create", return_value=cm),
+            pytest.raises(LoginFailed, match="Yandex Music"),
+        ):
+            async with authenticator():
+                pass
+        fake_client.start_device_login.assert_not_awaited()
+
+    async def test_missing_borrowed_token_fails_fast(self) -> None:
+        mass = mock.MagicMock()
+        authenticator = make_authenticator(
+            mass=mass,
+            session_id="s1",
+            cached_x_token=None,
+            allow_device_flow=False,
+        )
+        fake_client = mock.MagicMock()
+        fake_client.start_device_login = mock.AsyncMock()
+        cm = mock.MagicMock()
+        cm.__aenter__ = mock.AsyncMock(return_value=fake_client)
+        cm.__aexit__ = mock.AsyncMock(return_value=False)
+        with (
+            mock.patch("ya_passport_auth.PassportClient.create", return_value=cm),
+            pytest.raises(LoginFailed, match="Yandex Music"),
+        ):
+            async with authenticator():
+                pass
+        fake_client.start_device_login.assert_not_awaited()
+
+
+class TestAutoCreateBorrow:
+    async def test_borrow_uses_ym_token_without_persistence(self) -> None:
+        mass = _make_mass({"ym-a": "Main"})
+        values: dict[str, Any] = {
+            CONF_YM_INSTANCE: "ym-a",
+            "session_id": "s1",
+            "instance_name": "Test",
+            "external_base_url": "https://ma.example.com",
+            "cloud_instance_id": "ci-1",
+        }
+        with (
+            mock.patch("provider.make_authenticator") as make_auth,
+            mock.patch("provider.auto_create_skill", new_callable=mock.AsyncMock) as create,
+        ):
+            create.side_effect = RuntimeError("stop after auth wiring")
+            await _run_auto_create_action(mass, values, "cloud_plus", None)
+        kwargs = make_auth.call_args.kwargs
+        assert kwargs["cached_x_token"] == "test-x-ym"
+        assert kwargs["allow_device_flow"] is False
+        assert kwargs["on_token_obtained"] is None
+        assert not values.get(CONF_AUTH_X_TOKEN)
+
+    async def test_borrow_source_error_lands_in_artifacts(self) -> None:
+        mass = _make_mass({"ym-a": "Main"})
+        mass.get_provider.return_value = None  # instance not loaded
+        values: dict[str, Any] = {
+            CONF_YM_INSTANCE: "ym-a",
+            "session_id": "s1",
+            "external_base_url": "https://ma.example.com",
+            "cloud_instance_id": "ci-1",
+        }
+        with mock.patch("provider.make_authenticator") as make_auth:
+            await _run_auto_create_action(mass, values, "cloud_plus", None)
+        make_auth.assert_not_called()
+        artifacts = json.loads(str(values[CONF_AUTO_CREATE_ARTIFACTS]))
+        assert artifacts["state"] == "failed"
+        assert "not loaded" in artifacts["last_error"]


### PR DESCRIPTION
Phase 4 adoption for smarthome (spec: `specs/inprogress/0001-borrow-account-source.md`, size S) — completes the borrow wave (station#101, alice#73, ynison#102). Adds the **Yandex account source** dropdown (key `ym_instance`, `__own__` sentinel): skill auto-create authenticates with a linked `yandex_music` instance's x_token via `ya-passport-auth[ma]==1.7.0`'s `BorrowedCredentialSource`.

- `make_authenticator` gains `allow_device_flow`: with a borrowed token, a missing/rejected credential raises `LoginFailed` with "re-authenticate the Yandex Music provider" — never a silent Device Flow fallback (that would create the second token family borrow avoids). The `AuthenticatorCM` contract, cached fast path and own-mode behavior are unchanged.
- Read-only: `on_token_obtained` is not wired while borrowing — nothing lands in this provider's `auth_x_token` storage.
- Source errors (instance not loaded / no x_token) land in `artifacts.last_error` for the status banner; stale selection normalizes to own.

Also fixes the conftest `_ConfigValueOption` stub to the models' current `(value, title)` order. TDD: 6 red-first tests; 232 passed; ruff clean. Note: this repo is inlined upstream — flows there with the next sync. Companion: trudenboy/ma-provider-tools#108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)