### PR TITLE
reverse-sync: Complete setup flow translations for late-migrated providers (#5024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -700,3 +700,4 @@ Voice-UX overhaul of the experimental Dialogs skill, driven by the research writ
 ### Notes
 - on_off: "включи" = play/resume, "выключи" = stop. Device always reports as "on" while player is available.
 - Yandex Smart Home API does **not** support `play_media` for third-party devices.
+- Reverse-synced upstream PR #5024 (WIP)

--- a/provider/strings.json
+++ b/provider/strings.json
@@ -95,6 +95,53 @@
       "label": "Yandex Passport x_token (cached)"
     }
   },
+  "setup_flow": {
+    "user": {
+      "title": "Choose how to connect",
+      "description": "Select a connection mode and the Yandex account to use. Cloud is the simplest; Cloud Plus and Direct set up a private skill."
+    },
+    "registering": {
+      "progress_text": "Registering a cloud relay for this instance..."
+    },
+    "skill_method": {
+      "title": "How should the skill be set up?",
+      "description": "Create the Yandex Dialogs skill automatically, or use the ID of a skill you already created."
+    },
+    "skill_id": {
+      "title": "Enter your skill ID",
+      "description": "Paste the ID of the Yandex Dialogs skill you created."
+    },
+    "creating_skill": {
+      "progress_text": "Creating the Yandex Dialogs skill..."
+    },
+    "device_login": {
+      "title": "Sign in to Yandex",
+      "description": "Open the verification URL and enter the code shown to sign in with Yandex.",
+      "progress_text": "Waiting for you to enter the code and confirm in the Yandex app..."
+    },
+    "skill_token": {
+      "title": "Enter the skill OAuth token",
+      "description": "Paste the OAuth token for your Yandex Dialogs skill. Use the link next to the field to obtain it."
+    },
+    "fetching_otp": {
+      "progress_text": "Fetching the one-time linking code..."
+    },
+    "cloud_otp": {
+      "progress_text": "Enter this one-time code in the Yandex app to link your account."
+    },
+    "cloud_confirm": {
+      "title": "Confirm in the Yandex app",
+      "description": "Enter the one-time code shown in the Yandex app, then continue once your account is linked."
+    },
+    "abort": {
+      "device_login_denied": "Sign-in was denied in the Yandex app."
+    }
+  },
+  "errors": {
+    "direct_requires_https": "Direct mode needs Music Assistant to be reachable over HTTPS. Set an external HTTPS URL and try again.",
+    "skill_token_required": "Enter the skill's OAuth token to continue.",
+    "no_borrowed_token": "The linked Yandex Music account has no session token. Authenticate the Yandex Music provider (with Remember session enabled) and retry."
+  },
   "manifest": {
     "description": "Expose Music Assistant players to Yandex Alice via Yandex Smart Home API."
   }

--- a/specs/inprogress/reverse-sync-pr5024.md
+++ b/specs/inprogress/reverse-sync-pr5024.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #5024
+
+WIP=1
+
+Ported from music-assistant/server#5024 into `yandex_smarthome`.
+
+## Summary
+
+_TODO: describe the change._


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5024 into the `yandex_smarthome` provider.

Original author: @marcelveldt (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally