### PR TITLE
reverse-sync: Retire the AUTH_SESSION auth-popup mechanism (#5030)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -700,3 +700,4 @@ Voice-UX overhaul of the experimental Dialogs skill, driven by the research writ
 ### Notes
 - on_off: "включи" = play/resume, "выключи" = stop. Device always reports as "on" while player is available.
 - Yandex Smart Home API does **not** support `play_media` for third-party devices.
+- Reverse-synced upstream PR #5030 (WIP)

--- a/specs/inprogress/reverse-sync-pr5030.md
+++ b/specs/inprogress/reverse-sync-pr5030.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #5030
+
+WIP=1
+
+Ported from music-assistant/server#5030 into `yandex_smarthome`.
+
+## Summary
+
+_TODO: describe the change._


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5030 into the `yandex_smarthome` provider.

> ⚠ Patch applied with **conflicts** — `.rej`/markers left in the tree. Resolve them before marking ready.


Original author: @marcelveldt (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally